### PR TITLE
✨[Feat] 전역 예외 처리 추가

### DIFF
--- a/src/main/java/com/ureka/techpost/global/exception/CustomException.java
+++ b/src/main/java/com/ureka/techpost/global/exception/CustomException.java
@@ -1,0 +1,22 @@
+package com.ureka.techpost.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    private String info;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String info) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.info = info;
+    }
+}

--- a/src/main/java/com/ureka/techpost/global/exception/ErrorCode.java
+++ b/src/main/java/com/ureka/techpost/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.ureka.techpost.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 예시
+    //Post
+    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 게시글을 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND , "해당 댓글을 찾을 수 없습니다.");
+
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/ureka/techpost/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ureka/techpost/global/exception/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.ureka.techpost.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    public static ResponseEntity<ErrorResponse> fromException(CustomException e) {
+        String message = e.getErrorCode().getMessage();
+        if (e.getInfo() != null) {
+            message += " " + e.getInfo();
+        }
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.builder()
+                        .status(e.getErrorCode().getStatus())
+                        .code(e.getErrorCode().name())
+                        .message(message)
+                        .build());
+    }
+}

--- a/src/main/java/com/ureka/techpost/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ureka/techpost/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.ureka.techpost.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        return ErrorResponse.fromException(e);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.builder()
+                        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .code("INTERNAL_SERVER_ERROR")
+                        .message("서버 내부 오류가 발생했습니다.")
+                        .build());
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 전역 예외 처리를 위한 exception 폴더 추가
-  GlobalExceptionHandler로 컨트롤러에서 발생하는 예외 처리
- 예외 처리가 필요한 경우 , ErrorCode에 추가하신 후 아래와 같이 사용하시면 됩니다.

```
 Post post = postRepository.findBypostId(postId)
                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
```

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
ex) feat/global-exception-> main

### 기타
지금 보니까 apiPayload 안에도 error 처리하는 게 있고 auth 폴더 안에도 exception 처리하는 게 있더라고요. 
이걸 exception 폴더안에 있는 전역 에러 핸들러로 처리하는 게 나을 것 같긴 합니다...
하지만  제가 파일을 없애자니 좀 그런 것 같아서 각자 맡으신 분이 파일 수정을 하시는 건 어떨까요?