### PR TITLE
[Refactor] 캐싱 로직 수정 및 성능 개선

### DIFF
--- a/src/main/java/com/ureka/techpost/domain/comment/service/CommentService.java
+++ b/src/main/java/com/ureka/techpost/domain/comment/service/CommentService.java
@@ -39,7 +39,6 @@ public class CommentService {
     private final PostRedisService postRedisService;
 
     @Transactional
-    @CacheEvict(value = "postComments", key = "#postId")
     public void createComment(CommentRequestDTO commentRequestDTO, CustomUserDetails userDetails, Long postId){
 
         Post post = postRepository.findById(postId)
@@ -55,6 +54,8 @@ public class CommentService {
                 .build();
 
         commentRepository.save(comment);
+        // 게시글 표시용
+        postRedisService.incrementCommentCount(postId);
     }
 
     @Transactional(readOnly = true)
@@ -106,8 +107,7 @@ public class CommentService {
         Long postId = comment.getPost().getId();
 
         commentRepository.delete(comment);
-
-        // 캐시 삭제 메서드 호출 (수동 Evict)
-        postRedisService.clearCommentCount(postId);
+        // 게시글 표시용
+        postRedisService.decrementCommentCount(postId);
     }
 }

--- a/src/main/java/com/ureka/techpost/domain/likes/service/LikesService.java
+++ b/src/main/java/com/ureka/techpost/domain/likes/service/LikesService.java
@@ -25,7 +25,6 @@ public class LikesService {
     private final PostRedisService postRedisService;
 
     @Transactional
-    @CacheEvict(value = "postLikes", key = "#postId")
     public void createLike(Long postId, CustomUserDetails userDetails) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
@@ -45,10 +44,11 @@ public class LikesService {
 
         // 랭킹 점수 실시간 반영 (ZSet)
         postRedisService.incrementLikeRanking(postId);
+        // 게시글 표시용
+        postRedisService.incrementLikeCount(postId);
     }
 
     @Transactional
-    @CacheEvict(value = "postLikes", key = "#postId")
     public void deleteLike(Long postId, CustomUserDetails userDetails) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
@@ -66,5 +66,7 @@ public class LikesService {
 
         // 랭킹 점수 차감 (ZSet)
         postRedisService.decrementLikeRanking(postId);
+        // 게시글 표시용
+        postRedisService.decrementLikeCount(postId);
     }
 }

--- a/src/main/java/com/ureka/techpost/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/ureka/techpost/domain/post/repository/PostRepositoryCustom.java
@@ -7,11 +7,11 @@ import org.springframework.data.domain.Pageable;
 /**
  * @file PostRepositoryCustom.java
  * @author 최승언
- * @version 1.0
+ * @version 1.1
  * @since 2025-12-09
  * @description QueryDSL을 사용한 동적 쿼리 및 검색 기능을 정의하기 위한 커스텀 Repository 인터페이스입니다.
  */
 
 public interface PostRepositoryCustom {
-    Page<PostResponseDTO> search(String keyword, String publisher, Pageable pageable);
+    Page<Long> searchIds(String keyword, String sourceName, Pageable pageable);
 }

--- a/src/main/java/com/ureka/techpost/domain/post/service/PostRedisService.java
+++ b/src/main/java/com/ureka/techpost/domain/post/service/PostRedisService.java
@@ -21,6 +21,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * @file PostRedisService.java
+ * @author 최승언
+ * @version 1.1
+ * @since 2025-12-12
+ * @description redis에 캐싱하는 비즈니스 로직을 구현한 서비스 클래스입니다.
+ */
+
 @Service
 @RequiredArgsConstructor
 public class PostRedisService {
@@ -44,6 +52,21 @@ public class PostRedisService {
         if (cache != null) {
             cache.put(dbDto.getId(), dbDto);
         }
+    }
+
+    // 여러 ID의 DTO를 한 번에 조회
+    public List<PostResponseDTO> getPostDtoList(List<Long> postIds) {
+        List<String> keys = postIds.stream()
+                .map(id -> "posts::" + id)
+                .toList();
+
+        // MultiGet: 한 번의 통신으로 여러 키 조회
+        List<Object> results = redisTemplate.opsForValue().multiGet(keys);
+
+        // 결과를 DTO 리스트로 변환 (없으면 null이 들어있음)
+        return results.stream()
+                .map(obj -> (PostResponseDTO) obj)
+                .collect(Collectors.toList());
     }
 
     // 좋아요 수 가져오기

--- a/src/main/java/com/ureka/techpost/domain/post/service/PostRedisService.java
+++ b/src/main/java/com/ureka/techpost/domain/post/service/PostRedisService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.DefaultTypedTuple;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
@@ -34,9 +35,14 @@ import java.util.stream.Collectors;
 public class PostRedisService {
 
     private final PostRepository postRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
     private final LikesRepository likesRepository;
     private final CommentRepository commentRepository;
+
+    // 객체(DTO) 저장용
+    private final RedisTemplate<String, Object> redisTemplate;
+    // 숫자(Count) 연산용
+    private final StringRedisTemplate stringRedisTemplate;
+
     private final CacheManager cacheManager;
 
     private static final String CACHE_POSTS = "posts";
@@ -57,7 +63,7 @@ public class PostRedisService {
     // 여러 ID의 DTO를 한 번에 조회
     public List<PostResponseDTO> getPostDtoList(List<Long> postIds) {
         List<String> keys = postIds.stream()
-                .map(id -> "posts::" + id)
+                .map(id -> CACHE_POSTS + "::" + id)
                 .toList();
 
         // MultiGet: 한 번의 통신으로 여러 키 조회
@@ -69,72 +75,67 @@ public class PostRedisService {
                 .collect(Collectors.toList());
     }
 
+    // 키 생성 헬퍼 메서드
+    private String getLikeKey(Long postId) {
+        return CACHE_LIKES + "::" + postId;
+    }
+    private String getCommentKey(Long postId) {
+        return CACHE_COMMENTS + "::" + postId;
+    }
+
     // 좋아요 수 가져오기
     public Long getLikeCount(Long postId) {
+        String key = getLikeKey(postId);
+        String value = stringRedisTemplate.opsForValue().get(key);
 
-        Cache cache = cacheManager.getCache(CACHE_LIKES);
-
-        if (cache != null) {
-            Cache.ValueWrapper wrapper = cache.get(postId);
-
-            if (wrapper != null) {
-                Object value = wrapper.get();
-
-                if (value instanceof Number) {
-                    return ((Number) value).longValue();
-                }
-            }
+        // 캐시 히트
+        if (value != null) {
+            return Long.parseLong(value);
         }
 
+        // 캐시 미스
         Long dbCount = likesRepository.countByPostId(postId);
-
-        if (cache != null) {
-            cache.put(postId, dbCount);
-        }
-
+        stringRedisTemplate.opsForValue().set(key, dbCount.toString());
         return dbCount;
     }
 
     // 댓글 수 가져오기
     public Long getCommentCount(Long postId) {
+        String key = getCommentKey(postId);
+        String value = stringRedisTemplate.opsForValue().get(key);
 
-        Cache cache = cacheManager.getCache(CACHE_COMMENTS);
-
-        if (cache != null) {
-            Cache.ValueWrapper wrapper = cache.get(postId);
-
-            if (wrapper != null) {
-                Object value = wrapper.get();
-
-                if (value instanceof Number) {
-                    return ((Number) value).longValue();
-                }
-            }
+        if (value != null) {
+            return Long.parseLong(value);
         }
 
         Long dbCount = commentRepository.countByPostId(postId);
-
-        if (cache != null) {
-            cache.put(postId, dbCount);
-        }
-
+        stringRedisTemplate.opsForValue().set(key, dbCount.toString());
         return dbCount;
     }
 
-    public void clearCommentCount(Long postId) {
-        Cache cache = cacheManager.getCache("postComments");
-        if (cache != null) {
-            cache.evict(postId); // 해당 게시물의 댓글 수 캐시 삭제
-        }
+    /**
+     * redis 좋아요, 댓글 개수 증감
+     */
+    public void incrementLikeCount(Long postId) {
+        stringRedisTemplate.opsForValue().increment(getLikeKey(postId));
+    }
+    public void decrementLikeCount(Long postId) {
+        stringRedisTemplate.opsForValue().decrement(getLikeKey(postId));
+    }
+    public void incrementCommentCount(Long postId) {
+        stringRedisTemplate.opsForValue().increment(getCommentKey(postId));
+    }
+    public void decrementCommentCount(Long postId) {
+        stringRedisTemplate.opsForValue().decrement(getCommentKey(postId));
     }
 
-    // 좋아요 점수 올리기 (+1)
+    /**
+     * 랭킹 관련 점수 증감
+     */
     public void incrementLikeRanking(Long postId) {
         // ZSet에 해당 postId의 점수를 1 증가시킴 (없으면 자동 생성)
         redisTemplate.opsForZSet().incrementScore(RANKING_KEY, postId.toString(), 1);
     }
-
-    // 좋아요 점수 내리기 (-1)
     public void decrementLikeRanking(Long postId) {
         redisTemplate.opsForZSet().incrementScore(RANKING_KEY, postId.toString(), -1);
     }
@@ -164,7 +165,6 @@ public class PostRedisService {
         if (posts == null || posts.isEmpty()) {
             return;
         }
-
         for (Post post : posts) {
             redisTemplate.opsForZSet().add(RANKING_KEY, post.getId().toString(), 0.0);
         }


### PR DESCRIPTION
## 변경 사항

- 게시물 검색 쿼리와 댓글/좋아요 숫자 카운팅 쿼리 분리 및 중복 제거
- 기존에 목록 조회 시, 계속해서 redis에 게시물 데이터를 DB에서 검색하여 저장하는 로직
    - 조건의 맞는 id만 검색 -> redis 검색 -> 캐시 미스된 id만 DB에서 검색하여 본문 내용을 가져오는 로직으로 변경
    - redis에 게시물 데이터를 저장만하고 사용하지 않던 현상 수정

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 , 폴더명 , 파일 경로 수정
- [ ] 파일 혹은 폴더 삭제


### 반영 브랜치
refactor/search-counting -> main

### 기타